### PR TITLE
chore: move klipper python env to klippy-env dir

### DIFF
--- a/src/scripts/02-install-klipper
+++ b/src/scripts/02-install-klipper
@@ -30,8 +30,8 @@ apt-get -y --allow-downgrades --allow-remove-essential --allow-change-held-packa
 pushd /home/pi
   # Mostly taken from klipper/scripts/install-octopi.sh
   sudo -u pi git clone -b "$KLIPPER_BRANCH" --depth $KLIPPER_DEPTH "$KLIPPER_REPO" klipper
-  sudo -u pi virtualenv -p python2 klipper/venv
-  sudo -u pi klipper/venv/bin/pip install -r klipper/scripts/klippy-requirements.txt
+  sudo -u pi virtualenv -p python2 klippy-env
+  sudo -u pi klippy-env/bin/pip install -r klipper/scripts/klippy-requirements.txt
 
   cp klipper/scripts/klipper-start.sh /etc/init.d/klipper
   chmod 755 /etc/init.d/klipper

--- a/src/scripts/files/klipper/default
+++ b/src/scripts/files/klipper/default
@@ -1,4 +1,4 @@
 # Configuration for /etc/init.d/klipper
 KLIPPY_USER=pi
-KLIPPY_EXEC=/home/pi/klipper/venv/bin/python
+KLIPPY_EXEC=/home/pi/klippy-env/bin/python
 KLIPPY_ARGS="/home/pi/klipper/klippy/klippy.py /home/pi/printer.cfg -l /tmp/klippy.log"


### PR DESCRIPTION
this PR is to have the directory `~/klipper` clean to be able to update it via github (git pull).